### PR TITLE
[Chore] psycopg2대신 psycopg2-binary로 교체

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ packaging==25.0
 pandas==2.3.1
 pgvector==0.4.1
 pillow==11.3.0
-psycopg2==2.9.10
+psycopg2-binary==2.9.10
 pydantic==2.11.7
 pydantic_core==2.33.2
 python-dateutil==2.9.0.post0


### PR DESCRIPTION
## #️⃣연관된 이슈

> 업습니다.

## 📝작업 내용

> requirements.txt에서 psycopg2 대신 psycopg2-binary로 교체했습니다.

## 📷스크린샷 (선택)

> 

## 💬리뷰 요구사항(선택)

> 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * PostgreSQL 어댑터 의존성을 `psycopg2`에서 `psycopg2-binary`로 변경하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->